### PR TITLE
Add env unset

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -13,6 +13,8 @@ import (
 )
 
 func newEnvCmd(e shipyard.Engine) *cobra.Command {
+	var unset bool
+
 	envCmd := &cobra.Command{
 		Use:   "env",
 		Short: "Prints environment variables defined by the blueprint",
@@ -29,6 +31,12 @@ func newEnvCmd(e shipyard.Engine) *cobra.Command {
     
   # Set environment variables on Windows based systems
   Invoke-Expression "shipyard env" | ForEach-Object { Invoke-Expression $_ }
+
+  # Unset environment variables on Linux based systems
+  eval $(shipyard env --unset)
+
+  # Unset environment variables on Windows based systems
+  Invoke-Expression "shipyard env --unset" | ForEach-Object { Invoke-Expression $_ }
 `,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -41,6 +49,9 @@ func newEnvCmd(e shipyard.Engine) *cobra.Command {
 			}
 
 			prefix := "export "
+			if unset {
+				prefix = "unset "
+			}
 			if runtime.GOOS == "windows" {
 				prefix = "$Env:"
 			}
@@ -64,5 +75,6 @@ func newEnvCmd(e shipyard.Engine) *cobra.Command {
 		SilenceUsage: true,
 	}
 
+	envCmd.Flags().BoolVarP(&unset, "unset", "", false, "When set to true Shipyard will print unset commands for environment variables defined by the blueprint")
 	return envCmd
 }

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -54,12 +54,19 @@ func newEnvCmd(e shipyard.Engine) *cobra.Command {
 			}
 			if runtime.GOOS == "windows" {
 				prefix = "$Env:"
+				if unset {
+					prefix = "Env:\\"
+				}
 			}
 
 			if c.Blueprint != nil && len(c.Blueprint.Environment) > 0 {
 				for _, env := range c.Blueprint.Environment {
 					env.Value = strings.ReplaceAll(env.Value, `\`, `\\`)
-					fmt.Printf("%s%s=\"%s\"\n", prefix, env.Key, env.Value)
+					if unset {
+						fmt.Printf("%s%s\n", prefix, env.Key)
+					} else {
+						fmt.Printf("%s%s=\"%s\"\n", prefix, env.Key, env.Value)
+					}
 				}
 			}
 

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -36,7 +36,7 @@ func newEnvCmd(e shipyard.Engine) *cobra.Command {
   eval $(shipyard env --unset)
 
   # Unset environment variables on Windows based systems
-  Invoke-Expression "shipyard env --unset" | ForEach-Object { Invoke-Expression $_ }
+  Invoke-Expression "shipyard env --unset" | ForEach-Object { Remove-Item $_ }
 `,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,7 +74,11 @@ func newEnvCmd(e shipyard.Engine) *cobra.Command {
 			for _, r := range c.Resources {
 				if r.Info().Type == config.TypeOutput {
 					val := strings.ReplaceAll(r.(*config.Output).Value, `\`, `\\`)
-					fmt.Printf("%s%s=\"%s\"\n", prefix, r.Info().Name, val)
+					if unset {
+						fmt.Printf("%s%s\n", prefix, r.Info().Name)
+					} else {
+						fmt.Printf("%s%s=\"%s\"\n", prefix, r.Info().Name, val)
+					}
 				}
 			}
 			return nil

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -48,6 +48,20 @@ func TestSetsEnvironmentVariables(t *testing.T) {
 	assert.Contains(t, `export apples="pears"`, out.String())
 }
 
+func TestUnsetsEnvironmentVariables(t *testing.T) {
+	en := setupEnvState(t, envState)
+	en.Flags().Set("unset", "true")
+	out := bytes.NewBufferString("")
+	en.SetOutput(out)
+
+	err := en.Execute()
+	assert.NoError(t, err)
+
+	assert.Contains(t, `unset foo="bar"`, out.String())
+	assert.Contains(t, `unset abc="12\"3"`, out.String())
+	assert.Contains(t, `unset apples="pears"`, out.String())
+}
+
 var envState = `
 {
   "blueprint": {

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -57,9 +57,9 @@ func TestUnsetsEnvironmentVariables(t *testing.T) {
 	err := en.Execute()
 	assert.NoError(t, err)
 
-	assert.Contains(t, `unset foo="bar"`, out.String())
-	assert.Contains(t, `unset abc="12\"3"`, out.String())
-	assert.Contains(t, `unset apples="pears"`, out.String())
+	assert.Contains(t, `unset foo`, out.String())
+	assert.Contains(t, `unset abc`, out.String())
+	assert.Contains(t, `unset apples`, out.String())
 }
 
 var envState = `


### PR DESCRIPTION
Adds --unset flag to the shipyard env
    - add unit test for --unest flag
    - add help text for both unix base and windows
    - add flag to return os appropriate commands to unset shipyard env vars